### PR TITLE
Allow simulated double press

### DIFF
--- a/client_commandline/src/client_commandline.cpp
+++ b/client_commandline/src/client_commandline.cpp
@@ -80,7 +80,7 @@ void buttonEvent(int argc, const char* argv[]) {
 	inputEmulator.connect();
 	inputEmulator.openvrButtonEvent(eventType, deviceId, buttonId, 0.0);
 	if (noHold) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(500));
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
 		if (eventType == vrinputemulator::ButtonEventType::ButtonPressed) {
 			eventType = vrinputemulator::ButtonEventType::ButtonUnpressed;
 		} else {


### PR DESCRIPTION
The current press wait time (500ms) is too high to simulate double press.
If it is reduced from 500ms to 50ms then it is possible to simulate double press of the system button to toggle the room view camera via batch file.

```
.\client_commandline.exe buttonevent press 1 0
.\client_commandline.exe buttonevent press 1 0
```

Thanks a lot for creating and sharing your code. I've been looking for a long time for a solution to switch the room view camera on/off from Unity. And this seems to solve it.