### PR TITLE
Add driver interface for client-space universe offsets

### DIFF
--- a/driver_vrinputemulator/src/com/shm/driver_ipc_shm.cpp
+++ b/driver_vrinputemulator/src/com/shm/driver_ipc_shm.cpp
@@ -607,6 +607,8 @@ void IpcShmCommunicator::_ipcThreadFunc(IpcShmCommunicator* _this, ServerDriver 
 										resp.msg.dm_deviceOffsets.driverFromHeadTranslationOffset = info->driverFromHeadTranslationOffset();
 										resp.msg.dm_deviceOffsets.deviceRotationOffset = info->deviceRotationOffset();
 										resp.msg.dm_deviceOffsets.deviceTranslationOffset = info->deviceTranslationOffset();
+										resp.msg.dm_deviceOffsets.clientRotationOffset = info->clientRotationOffset();
+										resp.msg.dm_deviceOffsets.clientTranslationOffset = info->clientTranslationOffset();
 									}
 								}
 								if (resp.status != ipc::ReplyStatus::Ok) {
@@ -653,6 +655,12 @@ void IpcShmCommunicator::_ipcThreadFunc(IpcShmCommunicator* _this, ServerDriver 
 											if (message.msg.dm_DeviceOffsets.deviceTranslationOffsetValid) {
 												info->deviceTranslationOffset() = message.msg.dm_DeviceOffsets.deviceTranslationOffset;
 											}
+											if (message.msg.dm_DeviceOffsets.clientRotationOffsetValid) {
+												info->clientRotationOffset() = message.msg.dm_DeviceOffsets.clientRotationOffset;
+											}
+											if (message.msg.dm_DeviceOffsets.clientTranslationOffsetValid) {
+												info->clientTranslationOffset() = message.msg.dm_DeviceOffsets.clientTranslationOffset;
+											}
 											break;
 										case 1:
 											if (message.msg.dm_DeviceOffsets.worldFromDriverRotationOffsetValid) {
@@ -672,6 +680,12 @@ void IpcShmCommunicator::_ipcThreadFunc(IpcShmCommunicator* _this, ServerDriver 
 											}
 											if (message.msg.dm_DeviceOffsets.deviceTranslationOffsetValid) {
 												info->deviceTranslationOffset() = info->deviceTranslationOffset() + message.msg.dm_DeviceOffsets.deviceTranslationOffset;
+											}
+											if (message.msg.dm_DeviceOffsets.clientRotationOffsetValid) {
+												info->clientRotationOffset() = message.msg.dm_DeviceOffsets.clientRotationOffset * info->clientRotationOffset();
+											}
+											if (message.msg.dm_DeviceOffsets.clientTranslationOffsetValid) {
+												info->clientTranslationOffset() = info->clientTranslationOffset() + message.msg.dm_DeviceOffsets.clientTranslationOffset;
 											}
 											break;
 										}

--- a/driver_vrinputemulator/src/devicemanipulation/DeviceManipulationHandle.cpp
+++ b/driver_vrinputemulator/src/devicemanipulation/DeviceManipulationHandle.cpp
@@ -135,6 +135,16 @@ bool DeviceManipulationHandle::handlePoseUpdate(uint32_t& unWhichDevice, vr::Dri
 			if (m_deviceTranslationOffset.v[0] != 0.0 || m_deviceTranslationOffset.v[1] != 0.0 || m_deviceTranslationOffset.v[2] != 0.0) {
 				VECTOR_ADD(newPose.vecPosition, m_deviceTranslationOffset);
 			}
+			if (m_clientRotationOffset.w != 1.0 || m_clientRotationOffset.x != 0.0
+				|| m_clientRotationOffset.y != 0.0 || m_clientRotationOffset.z != 0.0) {
+				newPose.qWorldFromDriverRotation = m_clientRotationOffset * newPose.qWorldFromDriverRotation;
+			}
+			if (m_clientTranslationOffset.v[0] != 0.0 || m_clientTranslationOffset.v[1] != 0.0 || m_clientTranslationOffset.v[2] != 0.0) {
+				vr::HmdVector3d_t rotatedTranslation = vrmath::quaternionRotateVector(m_clientRotationOffset, newPose.vecWorldFromDriverTranslation);
+				newPose.vecWorldFromDriverTranslation[0] = rotatedTranslation.v[0] + m_clientTranslationOffset.v[0];
+				newPose.vecWorldFromDriverTranslation[1] = rotatedTranslation.v[1] + m_clientTranslationOffset.v[1];
+				newPose.vecWorldFromDriverTranslation[2] = rotatedTranslation.v[2] + m_clientTranslationOffset.v[2];
+			}
 		}
 		
 		m_motionCompensationManager._applyMotionCompensation(newPose, this);

--- a/driver_vrinputemulator/src/devicemanipulation/DeviceManipulationHandle.h
+++ b/driver_vrinputemulator/src/devicemanipulation/DeviceManipulationHandle.h
@@ -50,6 +50,8 @@ private:
 	vr::HmdVector3d_t m_driverFromHeadTranslationOffset = { 0.0, 0.0, 0.0 };
 	vr::HmdQuaternion_t m_deviceRotationOffset = { 1.0, 0.0, 0.0, 0.0 };
 	vr::HmdVector3d_t m_deviceTranslationOffset = { 0.0, 0.0, 0.0 };
+	vr::HmdQuaternion_t m_clientRotationOffset = { 1.0, 0.0, 0.0, 0.0 };
+	vr::HmdVector3d_t m_clientTranslationOffset = { 0.0, 0.0, 0.0 };
 
 	struct DigitalInputRemappingInfo {
 		int state = 0;
@@ -149,6 +151,10 @@ public:
 	vr::HmdQuaternion_t& deviceRotationOffset() { return m_deviceRotationOffset; }
 	const vr::HmdVector3d_t& deviceTranslationOffset() const { return m_deviceTranslationOffset; }
 	vr::HmdVector3d_t& deviceTranslationOffset() { return m_deviceTranslationOffset; }
+	const vr::HmdQuaternion_t& clientRotationOffset() const { return m_clientRotationOffset; }
+	vr::HmdQuaternion_t& clientRotationOffset() { return m_clientRotationOffset; }
+	const vr::HmdVector3d_t& clientTranslationOffset() const { return m_clientTranslationOffset; }
+	vr::HmdVector3d_t& clientTranslationOffset() { return m_clientTranslationOffset; }
 
 	void setDigitalInputRemapping(uint32_t buttonId, const DigitalInputRemapping& remapping);
 	DigitalInputRemapping getDigitalInputRemapping(uint32_t buttonId);

--- a/lib_vrinputemulator/include/ipc_protocol.h
+++ b/lib_vrinputemulator/include/ipc_protocol.h
@@ -254,6 +254,11 @@ struct Request_DeviceManipulation_SetDeviceOffsets {
 	vr::HmdQuaternion_t deviceRotationOffset;
 	bool deviceTranslationOffsetValid;
 	vr::HmdVector3d_t deviceTranslationOffset;
+	// client universe offsets
+	bool clientRotationOffsetValid;
+	vr::HmdQuaternion_t clientRotationOffset;
+	bool clientTranslationOffsetValid;
+	vr::HmdVector3d_t clientTranslationOffset;
 };
 
 struct Request_DeviceManipulation_RedirectMode {
@@ -437,6 +442,8 @@ struct Reply_DeviceManipulation_GetDeviceOffsets {
 	vr::HmdVector3d_t driverFromHeadTranslationOffset;
 	vr::HmdQuaternion_t deviceRotationOffset;
 	vr::HmdVector3d_t deviceTranslationOffset;
+	vr::HmdQuaternion_t clientRotationOffset;
+	vr::HmdVector3d_t clientTranslationOffset;
 };
 
 struct Reply_InputRemapping_GetDigitalRemapping {


### PR DESCRIPTION
The existing WorldFromDriver rotation offset applies directly to `qWorldFromDriverRotation` and does not affect `vecWorldFromDriverTranslation`, which means any changes to `vecWorldFromDriverTranslation` originating from the true device driver will effectively cause the rotation offset to be applied relative to a different origin in client space.

In particular, when a lighthouse-tracked device loses tracking and comes up facing a different lighthouse than before, the WorldFromDriver transform will switch, and any calibrated translation offset needs to be adjusted to take this into account. This is fairly annoying when it occurs, and requires either switching the profile, cycling the devices tracking and bringing them up facing the original lighthouse, or restarting SteamVR with the devices facing the original lighthouse.

This PR introduces a new offset, which is effectively applied to the universe transform instead of the WorldFromDriver transform. It does this by applying the rotation offset to the incoming `vecWorldFromDriverTranslation` as well as `qWorldFromDriverRotation`.

I'm opening this without any client changes, since I want to gauge your interest in merging before continuing work.