### PR TITLE
Support new IVRDriverInput_002 interface

### DIFF
--- a/driver_vrinputemulator/src/hooks/common.cpp
+++ b/driver_vrinputemulator/src/hooks/common.cpp
@@ -27,6 +27,8 @@ std::shared_ptr<InterfaceHooks> InterfaceHooks::hookInterface(void* interfaceRef
 		retval = IVRServerDriverHost005Hooks::createHooks(interfaceRef);
 	} else if (interfaceVersion.compare("IVRDriverInput_001") == 0) {
 		retval = IVRDriverInput001Hooks::createHooks(interfaceRef);
+	} else if (interfaceVersion.compare("IVRDriverInput_002") == 0) {
+		retval = IVRDriverInput001Hooks::createHooks(interfaceRef);	
 	} else if (interfaceVersion.compare("ITrackedDeviceServerDriver_005") == 0) {
 		retval = ITrackedDeviceServerDriver005Hooks::createHooks(interfaceRef);
 	} else if (interfaceVersion.compare("IVRControllerComponent_001") == 0) {


### PR DESCRIPTION
OpenVR has an updated IVRDriverInput interface, which is now used by Vive. The interface doesn't differ from IVRDriverInput_001 except in terms of skeletal tracking which isn't supported by the emulator anyway, so it seems happy using the same hook.

